### PR TITLE
修复账号切换时界面不自动刷新的问题

### DIFF
--- a/app/src/main/java/com/muort/upworker/feature/dns/DnsFragment.kt
+++ b/app/src/main/java/com/muort/upworker/feature/dns/DnsFragment.kt
@@ -102,6 +102,14 @@ class DnsFragment : Fragment() {
                         Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
+                
+                launch {
+                    accountViewModel.defaultAccount.collect { account ->
+                        if (account != null) {
+                            dnsViewModel.loadDnsRecords(account)
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/muort/upworker/feature/kv/KvFragment.kt
+++ b/app/src/main/java/com/muort/upworker/feature/kv/KvFragment.kt
@@ -146,6 +146,14 @@ class KvFragment : Fragment() {
                         Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
+                
+                launch {
+                    accountViewModel.defaultAccount.collect { account ->
+                        if (account != null) {
+                            kvViewModel.loadNamespaces(account)
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/muort/upworker/feature/pages/PagesFragment.kt
+++ b/app/src/main/java/com/muort/upworker/feature/pages/PagesFragment.kt
@@ -100,6 +100,14 @@ class PagesFragment : Fragment() {
                         Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
+                
+                launch {
+                    accountViewModel.defaultAccount.collect { account ->
+                        if (account != null) {
+                            pagesViewModel.loadProjects(account)
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/muort/upworker/feature/r2/R2Fragment.kt
+++ b/app/src/main/java/com/muort/upworker/feature/r2/R2Fragment.kt
@@ -132,6 +132,14 @@ class R2Fragment : Fragment() {
                         Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
+                
+                launch {
+                    accountViewModel.defaultAccount.collect { account ->
+                        if (account != null) {
+                            r2ViewModel.loadBuckets(account)
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/muort/upworker/feature/route/RouteFragment.kt
+++ b/app/src/main/java/com/muort/upworker/feature/route/RouteFragment.kt
@@ -160,6 +160,16 @@ class RouteFragment : Fragment() {
                         Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
+                
+                launch {
+                    accountViewModel.defaultAccount.collect { account ->
+                        if (account != null) {
+                            workerViewModel.loadWorkerScripts(account)
+                            workerViewModel.loadRoutes(account)
+                            workerViewModel.loadCustomDomains(account)
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
- 在 DNS、Route、KV、Pages、R2 界面添加账号切换监听
- 当切换账号时自动重新加载对应数据
- 与 Worker 界面保持一致的用户体验