### PR TITLE
feat(account): API Token 输入框旁新增「权限」管理按钮

### DIFF
--- a/app/src/main/java/com/muort/upworker/core/model/ApiTokenModels.kt
+++ b/app/src/main/java/com/muort/upworker/core/model/ApiTokenModels.kt
@@ -1,0 +1,85 @@
+package com.muort.upworker.core.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Cloudflare API Token 相关数据模型
+ * 文档: https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/
+ */
+
+// ==================== Permission Groups ====================
+
+/**
+ * 权限组（来自 GET /user/tokens/permission_groups）
+ * name 仅为展示用（易变），创建 Token 时使用 id。
+ */
+data class PermissionGroup(
+    @SerializedName("id") val id: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("description") val description: String? = null,
+    @SerializedName("scopes") val scopes: List<String>? = null
+)
+
+/**
+ * 策略中对权限组的引用（创建/更新 Token 时只需 id）
+ */
+data class PermissionGroupRef(
+    @SerializedName("id") val id: String,
+    @SerializedName("name") val name: String? = null
+)
+
+/**
+ * 权限作用域分类（用于 UI 分组展示与构建策略 resources）
+ */
+enum class ScopeCategory { USER, ACCOUNT, ZONE }
+
+// ==================== Token Policy & Request ====================
+
+/**
+ * Token 访问策略
+ * - resources: 资源键值映射。值通常为 "*"（String），
+ *   或 "账号内全部 Zone" 时为嵌套 Map: {"com.cloudflare.api.account.zone.*":"*"}
+ * - 使用 Map<String, Any> 以兼容 Gson 的混合类型序列化/反序列化
+ */
+data class TokenPolicy(
+    @SerializedName("effect") val effect: String = "allow",
+    @SerializedName("resources") val resources: Map<String, Any>,
+    @SerializedName("permission_groups") val permissionGroups: List<PermissionGroupRef>
+)
+
+/**
+ * 创建 API Token 请求体（POST /user/tokens）
+ */
+data class CreateTokenRequest(
+    @SerializedName("name") val name: String,
+    @SerializedName("policies") val policies: List<TokenPolicy>,
+    @SerializedName("not_before") val notBefore: String? = null,
+    @SerializedName("expires_on") val expiresOn: String? = null
+)
+
+// ==================== Token Object (response) ====================
+
+/**
+ * API Token 对象（创建/列表/详情/verify 响应）
+ * value: Token 密钥，仅在创建时返回一次
+ */
+data class ApiToken(
+    @SerializedName("id") val id: String? = null,
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("status") val status: String? = null,
+    @SerializedName("policies") val policies: List<TokenPolicy>? = null,
+    @SerializedName("value") val value: String? = null,
+    @SerializedName("not_before") val notBefore: String? = null,
+    @SerializedName("expires_on") val expiresOn: String? = null,
+    @SerializedName("issued_on") val issuedOn: String? = null,
+    @SerializedName("modified_on") val modifiedOn: String? = null
+)
+
+/**
+ * 当前用户信息（GET /user，用于获取 USER_TAG 构建 user 作用域策略）
+ */
+data class CloudflareUser(
+    @SerializedName("id") val id: String? = null,
+    @SerializedName("email") val email: String? = null,
+    @SerializedName("username") val username: String? = null
+)

--- a/app/src/main/java/com/muort/upworker/core/network/CloudFlareApi.kt
+++ b/app/src/main/java/com/muort/upworker/core/network/CloudFlareApi.kt
@@ -2092,4 +2092,78 @@ interface CloudFlareApi {
         @Path("zone_id") zoneId: String,
         @Path("snippet_name") snippetName: String
     ): Response<CloudFlareResponse<Unit>>
+
+    // ==================== API Tokens (权限管理) ====================
+    // 文档: https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/
+
+    /**
+     * 列出所有可用的权限组
+     * GET /user/tokens/permission_groups
+     * 需要 Token 具有 "API Tokens Read" 或 "API Tokens Write" 权限
+     */
+    @GET("user/tokens/permission_groups")
+    suspend fun listPermissionGroups(
+        @Header("Authorization") token: String?,
+        @Header("X-Auth-Email") email: String?,
+        @Header("X-Auth-Key") apiKey: String?
+    ): Response<CloudFlareResponse<List<PermissionGroup>>>
+
+    /**
+     * 校验当前 Token，返回其 id 与状态
+     * GET /user/tokens/verify
+     */
+    @GET("user/tokens/verify")
+    suspend fun verifyToken(
+        @Header("Authorization") token: String?,
+        @Header("X-Auth-Email") email: String?,
+        @Header("X-Auth-Key") apiKey: String?
+    ): Response<CloudFlareResponse<ApiToken>>
+
+    /**
+     * 获取指定 Token 的详情（含策略/权限）
+     * GET /user/tokens/{token_id}
+     */
+    @GET("user/tokens/{token_id}")
+    suspend fun getTokenDetail(
+        @Header("Authorization") token: String?,
+        @Header("X-Auth-Email") email: String?,
+        @Header("X-Auth-Key") apiKey: String?,
+        @Path("token_id") tokenId: String
+    ): Response<CloudFlareResponse<ApiToken>>
+
+    /**
+     * 列出当前用户的所有 Token
+     * GET /user/tokens
+     */
+    @GET("user/tokens")
+    suspend fun listTokens(
+        @Header("Authorization") token: String?,
+        @Header("X-Auth-Email") email: String?,
+        @Header("X-Auth-Key") apiKey: String?
+    ): Response<CloudFlareResponse<List<ApiToken>>>
+
+    /**
+     * 创建 API Token（自定义权限）
+     * POST /user/tokens
+     * 响应中的 value 为 Token 密钥，仅返回一次
+     * 需要 Token 具有 "API Tokens Write" 权限
+     */
+    @POST("user/tokens")
+    suspend fun createApiToken(
+        @Header("Authorization") token: String?,
+        @Header("X-Auth-Email") email: String?,
+        @Header("X-Auth-Key") apiKey: String?,
+        @Body request: CreateTokenRequest
+    ): Response<CloudFlareResponse<ApiToken>>
+
+    /**
+     * 获取当前用户信息（用于 user 作用域策略的 USER_TAG）
+     * GET /user
+     */
+    @GET("user")
+    suspend fun getCurrentUser(
+        @Header("Authorization") token: String?,
+        @Header("X-Auth-Email") email: String?,
+        @Header("X-Auth-Key") apiKey: String?
+    ): Response<CloudFlareResponse<CloudflareUser>>
 }

--- a/app/src/main/java/com/muort/upworker/core/repository/ApiTokenRepository.kt
+++ b/app/src/main/java/com/muort/upworker/core/repository/ApiTokenRepository.kt
@@ -1,0 +1,334 @@
+package com.muort.upworker.core.repository
+
+import com.muort.upworker.core.model.Account
+import com.muort.upworker.core.model.AccountInfo
+import com.muort.upworker.core.model.ApiToken
+import com.muort.upworker.core.model.CloudflareUser
+import com.muort.upworker.core.model.CreateTokenRequest
+import com.muort.upworker.core.model.PermissionGroup
+import com.muort.upworker.core.model.PermissionGroupRef
+import com.muort.upworker.core.model.Resource
+import com.muort.upworker.core.model.ScopeCategory
+import com.muort.upworker.core.model.TokenPolicy
+import com.muort.upworker.core.model.ZoneInfo
+import com.muort.upworker.core.network.CloudFlareApi
+import com.muort.upworker.core.util.AuthHelper
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * API Token 权限管理仓库
+ * 负责权限组获取、当前 Token 校验/详情、以及创建自定义权限 Token
+ */
+@Singleton
+class ApiTokenRepository @Inject constructor(
+    private val api: CloudFlareApi
+) {
+
+    private fun auth(account: Account) = Triple(
+        AuthHelper.getBearerToken(account),
+        AuthHelper.getEmail(account),
+        AuthHelper.getGlobalApiKey(account)
+    )
+
+    /** 获取所有可用权限组 */
+    suspend fun getPermissionGroups(account: Account): Resource<List<PermissionGroup>> {
+        return try {
+            val (token, email, key) = auth(account)
+            val response = api.listPermissionGroups(token, email, key)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "获取权限组失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), account))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "getPermissionGroups error")
+            Resource.Error(e.message ?: "网络错误")
+        }
+    }
+
+    /** 校验当前 Token（返回 id/status） */
+    suspend fun verifyToken(account: Account): Resource<ApiToken> {
+        return try {
+            val (token, email, key) = auth(account)
+            val response = api.verifyToken(token, email, key)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "Token 校验失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), account))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "verifyToken error")
+            Resource.Error(e.message ?: "网络错误")
+        }
+    }
+
+    /** 获取指定 Token 详情（含策略） */
+    suspend fun getTokenDetail(account: Account, tokenId: String): Resource<ApiToken> {
+        return try {
+            val (token, email, key) = auth(account)
+            val response = api.getTokenDetail(token, email, key, tokenId)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "获取 Token 详情失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), account))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "getTokenDetail error")
+            Resource.Error(e.message ?: "网络错误")
+        }
+    }
+
+    /** 获取账号列表（用于资源范围选择） */
+    suspend fun listAccounts(account: Account): Resource<List<AccountInfo>> {
+        return try {
+            val (token, email, key) = auth(account)
+            val response = api.listAccounts(token, email, key)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "获取账号列表失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), account))
+            }
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "网络错误")
+        }
+    }
+
+    /** 获取域名列表（用于资源范围选择） */
+    suspend fun listZones(account: Account): Resource<List<ZoneInfo>> {
+        return try {
+            val (token, email, key) = auth(account)
+            val response = api.listZones(token, email, key)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "获取域名列表失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), account))
+            }
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "网络错误")
+        }
+    }
+
+    /** 获取当前用户（用于 user 作用域策略） */
+    suspend fun getCurrentUser(account: Account): Resource<CloudflareUser> {
+        return try {
+            val (token, email, key) = auth(account)
+            val response = api.getCurrentUser(token, email, key)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "获取用户信息失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), account))
+            }
+        } catch (e: Exception) {
+            Resource.Error(e.message ?: "网络错误")
+        }
+    }
+
+    /**
+     * 创建自定义权限 API Token
+     * @param creator 用于创建新 Token 的凭据账号（需具有 "API Tokens Write" 权限）
+     * @param name 新 Token 名称
+     * @param selectedGroups 已选权限组（按作用域分类）
+     * @param accountScope 账号资源范围选择
+     * @param zoneScope 域名资源范围选择
+     * @param expiresOn 可选过期时间（ISO8601 UTC，如 "2026-08-01T00:00:00Z"）；null 表示永不过期
+     */
+    suspend fun createApiToken(
+        creator: Account,
+        name: String,
+        selectedGroups: Map<ScopeCategory, List<PermissionGroup>>,
+        accountScope: AccountResourceScope,
+        zoneScope: ZoneResourceScope,
+        expiresOn: String?
+    ): Resource<ApiToken> {
+        return try {
+            // 需要 user tag 才能构建 user 作用域策略
+            var userTag: String? = null
+            if (selectedGroups.containsKey(ScopeCategory.USER) &&
+                selectedGroups[ScopeCategory.USER].orEmpty().isNotEmpty()
+            ) {
+                when (val u = getCurrentUser(creator)) {
+                    is Resource.Success -> userTag = u.data.id
+                    is Resource.Error -> {
+                        return Resource.Error("获取用户信息失败（user 作用域策略所需）: ${u.message}")
+                    }
+                    is Resource.Loading -> {}
+                }
+                if (userTag.isNullOrBlank()) {
+                    return Resource.Error("无法获取用户标识，无法创建 user 作用域策略")
+                }
+            }
+
+            val policies = buildPolicies(selectedGroups, accountScope, zoneScope, userTag)
+            if (policies.isEmpty()) {
+                return Resource.Error("请至少选择一个权限")
+            }
+
+            val request = CreateTokenRequest(
+                name = name,
+                policies = policies,
+                notBefore = null,
+                expiresOn = expiresOn
+            )
+
+            val (token, email, key) = auth(creator)
+            val response = api.createApiToken(token, email, key, request)
+            if (response.isSuccessful) {
+                val body = response.body()
+                if (body?.success == true && body.result != null) {
+                    Resource.Success(body.result)
+                } else {
+                    Resource.Error(body?.errors?.firstOrNull()?.message ?: "创建 Token 失败")
+                }
+            } else {
+                Resource.Error(errorBody(response.code(), response.message(), creator))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "createApiToken error")
+            Resource.Error(e.message ?: "创建 Token 失败")
+        }
+    }
+
+    /**
+     * 根据所选权限组与资源范围构建策略列表（每种作用域一个策略）
+     */
+    private fun buildPolicies(
+        selected: Map<ScopeCategory, List<PermissionGroup>>,
+        accountScope: AccountResourceScope,
+        zoneScope: ZoneResourceScope,
+        userTag: String?
+    ): List<TokenPolicy> {
+        val policies = mutableListOf<TokenPolicy>()
+
+        // Zone 作用域策略
+        val zoneGroups = selected[ScopeCategory.ZONE].orEmpty()
+        if (zoneGroups.isNotEmpty()) {
+            policies.add(
+                TokenPolicy(
+                    effect = "allow",
+                    resources = zoneScope.toResources(),
+                    permissionGroups = zoneGroups.map { PermissionGroupRef(it.id) }
+                )
+            )
+        }
+
+        // Account 作用域策略
+        val accountGroups = selected[ScopeCategory.ACCOUNT].orEmpty()
+        if (accountGroups.isNotEmpty()) {
+            policies.add(
+                TokenPolicy(
+                    effect = "allow",
+                    resources = accountScope.toResources(),
+                    permissionGroups = accountGroups.map { PermissionGroupRef(it.id) }
+                )
+            )
+        }
+
+        // User 作用域策略
+        val userGroups = selected[ScopeCategory.USER].orEmpty()
+        if (userGroups.isNotEmpty() && !userTag.isNullOrBlank()) {
+            policies.add(
+                TokenPolicy(
+                    effect = "allow",
+                    resources = mapOf("com.cloudflare.api.user.$userTag" to "*"),
+                    permissionGroups = userGroups.map { PermissionGroupRef(it.id) }
+                )
+            )
+        }
+
+        return policies
+    }
+
+    /** 构造友好的错误信息（针对常见鉴权/权限错误给出提示） */
+    private fun errorBody(code: Int, message: String, account: Account): String {
+        return when (code) {
+            401, 403 -> "无权限或凭据无效($code)。此操作需要当前 Token 具有 \"API Tokens Read/Write\" 权限。" +
+                    if (account.getAuthTypeEnum() == com.muort.upworker.core.model.AuthType.GLOBAL_API_KEY)
+                        "（当前使用 Global API Key）" else ""
+            else -> "HTTP $code: $message"
+        }
+    }
+
+    // ==================== 资源范围 ====================
+
+    /** 账号资源范围 */
+    sealed class AccountResourceScope {
+        abstract fun toResources(): Map<String, Any>
+        /** 所有账号 */
+        data object AllAccounts : AccountResourceScope() {
+            override fun toResources() = mapOf<String, Any>("com.cloudflare.api.account.*" to "*")
+        }
+        /** 指定账号 */
+        data class SpecificAccount(val accountId: String) : AccountResourceScope() {
+            override fun toResources() = mapOf<String, Any>("com.cloudflare.api.account.$accountId" to "*")
+        }
+    }
+
+    /** 域名资源范围 */
+    sealed class ZoneResourceScope {
+        abstract fun toResources(): Map<String, Any>
+        /** 所有账号的所有 Zone */
+        data object AllZones : ZoneResourceScope() {
+            override fun toResources() = mapOf<String, Any>("com.cloudflare.api.account.zone.*" to "*")
+        }
+        /** 指定 Zone */
+        data class SpecificZone(val zoneId: String) : ZoneResourceScope() {
+            override fun toResources() = mapOf<String, Any>("com.cloudflare.api.account.zone.$zoneId" to "*")
+        }
+        /** 指定账号下的所有 Zone（嵌套资源） */
+        data class AllZonesInAccount(val accountId: String) : ZoneResourceScope() {
+            override fun toResources(): Map<String, Any> = mapOf(
+                "com.cloudflare.api.account.$accountId" to mapOf("com.cloudflare.api.account.zone.*" to "*")
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * 根据权限组的 scopes 字段判断其作用域分类
+         * - 含 "user" → User
+         * - 含 "zone" → Zone
+         * - 含 "account" → Account
+         */
+        fun categorize(scopes: List<String>?): ScopeCategory {
+            val joined = (scopes ?: emptyList()).joinToString(",").lowercase()
+            return when {
+                joined.contains("user") -> ScopeCategory.USER
+                joined.contains("zone") -> ScopeCategory.ZONE
+                joined.contains("account") -> ScopeCategory.ACCOUNT
+                else -> ScopeCategory.ACCOUNT
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/muort/upworker/feature/account/AccountEditFragment.kt
+++ b/app/src/main/java/com/muort/upworker/feature/account/AccountEditFragment.kt
@@ -19,7 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class AccountEditFragment : Fragment() {
+class AccountEditFragment : Fragment(), ApiTokenPermissionSheet.Listener {
     
     private var _binding: FragmentAccountEditBinding? = null
     private val binding get() = _binding!!
@@ -44,6 +44,7 @@ class AccountEditFragment : Fragment() {
         
         setupAuthTypeDropdown()
         setupFetchAccountIdButton()
+        setupPermissionButton()
         loadAccountIfEditing()
         setupSaveButton()
         setupZoneButtons()
@@ -123,6 +124,56 @@ class AccountEditFragment : Fragment() {
             }
             .setNegativeButton("取消", null)
             .show()
+    }
+
+    /**
+     * 设置 “权限” 按钮：打开 API Token 权限管理弹窗
+     * 可查看当前 Token 权限，或创建一个权限受控的新 Token 并回填
+     */
+    private fun setupPermissionButton() {
+        binding.tokenPermissionBtn.setOnClickListener {
+            val token = binding.tokenEditText.text.toString().trim()
+            val email = binding.emailEditText.text.toString().trim()
+            val globalApiKey = binding.globalApiKeyEditText.text.toString().trim()
+            val accountId = binding.accountIdEditText.text.toString().trim()
+            val name = binding.nameEditText.text.toString().trim().ifBlank { "临时" }
+
+            // 决定可用认证方式（优先当前选中，否则用已填写的凭据）
+            val hasToken = token.isNotEmpty()
+            val hasGlobal = email.isNotEmpty() && globalApiKey.isNotEmpty()
+            val authTypeToUse = when {
+                selectedAuthType == AuthType.TOKEN && hasToken -> AuthType.TOKEN
+                selectedAuthType == AuthType.GLOBAL_API_KEY && hasGlobal -> AuthType.GLOBAL_API_KEY
+                hasToken -> AuthType.TOKEN
+                hasGlobal -> AuthType.GLOBAL_API_KEY
+                else -> {
+                    showToast("请先填写 API Token 或 Global API Key 凭据")
+                    return@setOnClickListener
+                }
+            }
+
+            val tempAccount = com.muort.upworker.core.model.Account(
+                id = 0,
+                name = name,
+                accountId = accountId,
+                token = if (authTypeToUse == AuthType.TOKEN) token else "",
+                email = if (authTypeToUse == AuthType.GLOBAL_API_KEY) email else null,
+                globalApiKey = if (authTypeToUse == AuthType.GLOBAL_API_KEY) globalApiKey else null,
+                authType = authTypeToUse.name
+            )
+
+            ApiTokenPermissionSheet.newInstance(tempAccount)
+                .show(childFragmentManager, "ApiTokenPermissionSheet")
+        }
+    }
+
+    /** ApiTokenPermissionSheet.Listener：回填创建的新 Token */
+    override fun onFillApiToken(value: String) {
+        binding.tokenEditText.setText(value)
+        // 切换为 API Token 认证方式
+        selectedAuthType = AuthType.TOKEN
+        binding.authTypeRadioGroup.check(com.muort.upworker.R.id.radioToken)
+        showToast("已填入新创建的 API Token")
     }
     
     /**

--- a/app/src/main/java/com/muort/upworker/feature/account/ApiTokenPermissionSheet.kt
+++ b/app/src/main/java/com/muort/upworker/feature/account/ApiTokenPermissionSheet.kt
@@ -1,0 +1,472 @@
+package com.muort.upworker.feature.account
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.text.format.DateUtils
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.muort.upworker.core.model.Account
+import com.muort.upworker.core.model.AccountInfo
+import com.muort.upworker.core.model.AuthType
+import com.muort.upworker.core.model.PermissionGroup
+import com.muort.upworker.core.model.ScopeCategory
+import com.muort.upworker.core.model.ZoneInfo
+import com.muort.upworker.core.repository.ApiTokenRepository
+import com.muort.upworker.core.util.showToast
+import com.muort.upworker.databinding.DialogApiTokenPermissionBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * API Token 权限管理底部弹窗
+ *
+ * 两个能力：
+ * 1. 查看当前 Token 的权限策略（verify + GET /user/tokens/{id}）
+ * 2. 创建一个权限受控的新 Token（POST /user/tokens），可回填到左侧 API Token 输入框
+ *
+ * 仔细对齐 Cloudflare 创建 API Token 时的权限设置：权限组按 User/Account/Zone 作用域分组，
+ * 资源范围支持所有账号/指定账号、所有域名/指定域名，可选 TTL。
+ */
+@AndroidEntryPoint
+class ApiTokenPermissionSheet : BottomSheetDialogFragment() {
+
+    interface Listener {
+        /** 用户点击“填入 API Token”时回调 */
+        fun onFillApiToken(value: String)
+    }
+
+    private var _binding: DialogApiTokenPermissionBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ApiTokenViewModel by activityViewModels()
+
+    private var listener: Listener? = null
+
+    private lateinit var adapter: PermissionGroupAdapter
+
+    private var allGroups: List<PermissionGroup> = emptyList()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogApiTokenPermissionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        listener = parentFragment as? Listener ?: requireActivity() as? Listener
+
+        adapter = PermissionGroupAdapter { updateSelectedCount() }
+        binding.permRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.permRecyclerView.adapter = adapter
+        // 固定高度 + 内部滚动，配合外层 NestedScrollView 的嵌套滚动
+        binding.permRecyclerView.setHasFixedSize(true)
+
+        setupToggle()
+        setupSearch()
+        setupSpinners()
+        setupScopeRadios()
+        setupButtons()
+        observeViewModel()
+
+        // 构建临时凭据账号并加载数据
+        val account = buildAccountFromArgs()
+        viewModel.setCreatorAccount(account)
+        viewModel.loadPermissionData(account)
+    }
+
+    private fun buildAccountFromArgs(): Account {
+        val args = requireArguments()
+        return Account(
+            id = 0,
+            name = args.getString(ARG_ACCOUNT_NAME) ?: "临时",
+            accountId = args.getString(ARG_ACCOUNT_ID) ?: "",
+            token = args.getString(ARG_TOKEN) ?: "",
+            email = args.getString(ARG_EMAIL)?.ifBlank { null },
+            globalApiKey = args.getString(ARG_GLOBAL_KEY)?.ifBlank { null },
+            authType = args.getString(ARG_AUTH_TYPE) ?: AuthType.TOKEN.name
+        )
+    }
+
+    // ==================== 模式切换 ====================
+
+    private fun setupToggle() {
+        binding.toggleGroup.check(binding.btnViewCurrent.id)
+        showCurrentMode()
+        binding.toggleGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (!isChecked) return@addOnButtonCheckedListener
+            when (checkedId) {
+                binding.btnViewCurrent.id -> showCurrentMode()
+                binding.btnCreateNew.id -> showCreateMode()
+            }
+        }
+    }
+
+    private fun showCurrentMode() {
+        binding.currentSection.isVisible = true
+        binding.createSection.isVisible = false
+        binding.resultSection.isVisible = false
+    }
+
+    private fun showCreateMode() {
+        binding.currentSection.isVisible = false
+        binding.createSection.isVisible = true
+        binding.resultSection.isVisible = false
+    }
+
+    private fun showResultMode() {
+        binding.currentSection.isVisible = false
+        binding.createSection.isVisible = false
+        binding.resultSection.isVisible = true
+    }
+
+    // ==================== 搜索 ====================
+
+    private fun setupSearch() {
+        binding.searchEdit.addTextChangedListener(object : android.text.TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                adapter.setQuery(s?.toString() ?: "")
+                updateSelectedCount()
+            }
+            override fun afterTextChanged(s: android.text.Editable?) {}
+        })
+    }
+
+    // ==================== Spinners ====================
+
+    private fun setupSpinners() {
+        // 账号 Spinner
+        binding.accountSpinner.adapter = object : ArrayAdapter<AccountInfo>(
+            requireContext(), android.R.layout.simple_spinner_item
+        ) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val v = convertView ?: LayoutInflater.from(context)
+                    .inflate(android.R.layout.simple_spinner_item, parent, false)
+                val item = getItem(position) ?: return v
+                (v as TextView).text = "${item.name} (${item.id})"
+                return v
+            }
+
+            override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val v = LayoutInflater.from(context)
+                    .inflate(android.R.layout.simple_spinner_dropdown_item, parent, false)
+                (v as TextView).text = "${getItem(position)?.name} (${getItem(position)?.id})"
+                return v
+            }
+        }
+
+        // 域名 Spinner
+        binding.zoneSpinner.adapter = object : ArrayAdapter<ZoneInfo>(
+            requireContext(), android.R.layout.simple_spinner_item
+        ) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val v = convertView ?: LayoutInflater.from(context)
+                    .inflate(android.R.layout.simple_spinner_item, parent, false)
+                (v as TextView).text = getItem(position)?.name ?: ""
+                return v
+            }
+
+            override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val v = LayoutInflater.from(context)
+                    .inflate(android.R.layout.simple_spinner_dropdown_item, parent, false)
+                (v as TextView).text = getItem(position)?.name ?: ""
+                return v
+            }
+        }
+    }
+
+    // ==================== 资源范围 ====================
+
+    private fun setupScopeRadios() {
+        binding.accountScopeRadio.setOnCheckedChangeListener { _, checkedId ->
+            binding.accountSpinner.isVisible = checkedId == binding.radioSpecificAccount.id
+        }
+        binding.zoneScopeRadio.setOnCheckedChangeListener { _, checkedId ->
+            binding.zoneSpinner.isVisible = checkedId == binding.radioSpecificZone.id
+        }
+    }
+
+    // ==================== 按钮 ====================
+
+    private fun setupButtons() {
+        binding.closeBtn.setOnClickListener { dismiss() }
+
+        binding.refreshCurrentBtn.setOnClickListener {
+            val account = viewModel.creatorAccount.value ?: return@setOnClickListener
+            viewModel.loadCurrentTokenDetail(account)
+        }
+
+        binding.selectAllVisibleBtn.setOnClickListener { adapter.selectAllVisible(); updateSelectedCount() }
+        binding.clearSelectionBtn.setOnClickListener { adapter.clearSelection(); updateSelectedCount() }
+
+        binding.createTokenBtn.setOnClickListener { onCreateToken() }
+
+        binding.copyTokenBtn.setOnClickListener {
+            val value = viewModel.createdToken.value?.value ?: return@setOnClickListener
+            copyToClipboard(value)
+            showToast("已复制到剪贴板")
+        }
+        binding.fillTokenBtn.setOnClickListener {
+            val value = viewModel.createdToken.value?.value ?: return@setOnClickListener
+            listener?.onFillApiToken(value)
+            dismiss()
+        }
+        binding.createAnotherBtn.setOnClickListener {
+            viewModel.clearCreatedToken()
+            showCreateMode()
+        }
+    }
+
+    private fun onCreateToken() {
+        val account = viewModel.creatorAccount.value ?: run {
+            showToast("凭据缺失"); return
+        }
+        val name = binding.tokenNameEdit.text?.toString()?.trim().orEmpty()
+        if (name.isEmpty()) {
+            showToast("请输入 Token 名称"); return
+        }
+        if (adapter.selectedCount() == 0) {
+            showToast("请至少选择一个权限"); return
+        }
+
+        val selectedIds = adapter.getSelectedIds()
+        val selectedByCategory = mutableMapOf<ScopeCategory, MutableList<PermissionGroup>>()
+        allGroups.filter { it.id in selectedIds }.forEach { g ->
+            val cat = ApiTokenRepository.categorize(g.scopes)
+            selectedByCategory.getOrPut(cat) { mutableListOf() }.add(g)
+        }
+
+        val accountScope = if (binding.radioSpecificAccount.isChecked) {
+            val acc = (binding.accountSpinner.selectedItem as? AccountInfo)
+            if (acc == null) {
+                showToast("请选择账号"); return
+            }
+            ApiTokenRepository.AccountResourceScope.SpecificAccount(acc.id)
+        } else ApiTokenRepository.AccountResourceScope.AllAccounts
+
+        val zoneScope = if (binding.radioSpecificZone.isChecked) {
+            val zone = (binding.zoneSpinner.selectedItem as? ZoneInfo)
+            if (zone == null) {
+                showToast("请选择域名"); return
+            }
+            ApiTokenRepository.ZoneResourceScope.SpecificZone(zone.id)
+        } else ApiTokenRepository.ZoneResourceScope.AllZones
+
+        val expiresOn = computeExpiry()
+
+        viewModel.createApiToken(account, name, selectedByCategory, accountScope, zoneScope, expiresOn)
+    }
+
+    private fun computeExpiry(): String? {
+        val days = when (binding.expiryRadioGroup.checkedRadioButtonId) {
+            binding.radio7d.id -> 7
+            binding.radio30d.id -> 30
+            binding.radio90d.id -> 90
+            binding.radio1y.id -> 365
+            else -> return null
+        }
+        val future = System.currentTimeMillis() + days * DateUtils.DAY_IN_MILLIS
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+        return sdf.format(Date(future))
+    }
+
+    // ==================== 观察数据 ====================
+
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.permissionGroups.collect { renderGroups(it) } }
+                launch { viewModel.permAccounts.collect { fillAccountSpinner(it) } }
+                launch { viewModel.permZones.collect { fillZoneSpinner(it) } }
+                launch { viewModel.currentTokenDetail.collect { renderCurrentToken(it) } }
+                launch { viewModel.loading.collect { binding.loadingBar.isVisible = it } }
+                launch { viewModel.createdToken.collect {
+                    if (it != null && it.value != null) renderResult(it.name, it.value!!)
+                } }
+                launch { viewModel.message.collect { showToast(it) } }
+            }
+        }
+    }
+
+    private fun renderGroups(groups: List<PermissionGroup>) {
+        allGroups = groups
+        val items = mutableListOf<PermissionItem>()
+        // 按作用域分组：User / Account / Zone
+        val byCategory = groups.groupBy { ApiTokenRepository.categorize(it.scopes) }
+        ScopeCategory.values().forEach { cat ->
+            val list = byCategory[cat].orEmpty().sortedBy { it.name.lowercase() }
+            if (list.isNotEmpty()) {
+                items.add(PermissionItem.Header(PermissionGroupAdapter.titleFor(cat)))
+                items.addAll(list.map { PermissionItem.Group(it, cat) })
+            }
+        }
+        adapter.setData(items)
+        if (groups.isEmpty()) {
+            binding.selectedCountText.text = "无可用权限组（当前 Token 可能缺少 “API Tokens Read” 权限）"
+        } else {
+            updateSelectedCount()
+        }
+    }
+
+    private fun fillAccountSpinner(accounts: List<AccountInfo>) {
+        @Suppress("UNCHECKED_CAST")
+        val a = binding.accountSpinner.adapter as? ArrayAdapter<AccountInfo> ?: return
+        a.clear(); a.addAll(accounts); a.notifyDataSetChanged()
+    }
+
+    private fun fillZoneSpinner(zones: List<ZoneInfo>) {
+        @Suppress("UNCHECKED_CAST")
+        val a = binding.zoneSpinner.adapter as? ArrayAdapter<ZoneInfo> ?: return
+        a.clear(); a.addAll(zones); a.notifyDataSetChanged()
+    }
+
+    private fun updateSelectedCount() {
+        binding.selectedCountText.text = "已选 ${adapter.selectedCount()} 项"
+    }
+
+    // ==================== 当前 Token 渲染 ====================
+
+    private fun renderCurrentToken(token: com.muort.upworker.core.model.ApiToken?) {
+        val container = binding.currentPoliciesContainer
+        container.removeAllViews()
+        if (token == null) {
+            binding.currentInfoText.text = "无法读取当前 Token（需 “API Tokens Read” 权限）"
+            binding.currentErrorText.isVisible = true
+            binding.currentErrorText.text = "若使用 Global API Key 可直接读取；若为 API Token，则该 Token 需具备 “API Tokens Read” 权限。"
+            return
+        }
+        binding.currentErrorText.isVisible = false
+        val info = buildString {
+            token.id?.let { append("ID: $it\n") }
+            token.name?.let { append("名称: $it\n") }
+            append("状态: ${token.status ?: "未知"}")
+            token.expiresOn?.let { append("\n过期: $it") }
+        }
+        binding.currentInfoText.text = info
+
+        val policies = token.policies.orEmpty()
+        if (policies.isEmpty()) {
+            container.addView(makePolicyTextView("（无策略信息可读，或 Token 无任何权限策略）"))
+            return
+        }
+        policies.forEachIndexed { index, policy ->
+            val sb = buildString {
+                append("策略 ${index + 1}  [${policy.effect}]")
+                policy.resources.keys.forEach { res ->
+                    append("\n  • 资源: $res")
+                }
+                append("\n  权限:")
+                policy.permissionGroups.orEmpty().forEach { pg ->
+                    append("\n    - ${pg.name ?: pg.id}")
+                }
+            }
+            container.addView(makePolicyTextView(sb))
+        }
+    }
+
+    private fun makePolicyTextView(text: String): TextView {
+        // 解析主题颜色 colorPrimaryContainer（Material3 属性，兼容日/夜间模式）
+        val ta = requireContext().theme.obtainStyledAttributes(
+            intArrayOf(com.google.android.material.R.attr.colorPrimaryContainer)
+        )
+        val containerColor = ta.getColor(0, 0xFFEADDFF.toInt())
+        ta.recycle()
+        val radius = 12f * resources.displayMetrics.density
+        val bg = android.graphics.drawable.GradientDrawable().apply {
+            cornerRadius = radius
+            setColor(containerColor)
+        }
+        return TextView(requireContext()).apply {
+            this.text = text
+            textSize = 12f
+            setPadding((12 * resources.displayMetrics.density).toInt(),
+                (12 * resources.displayMetrics.density).toInt(),
+                (12 * resources.displayMetrics.density).toInt(),
+                (12 * resources.displayMetrics.density).toInt())
+            this.background = bg
+            val lp = ViewGroup.MarginLayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+            lp.bottomMargin = (8 * resources.displayMetrics.density).toInt()
+            layoutParams = lp
+            setOnClickListener {
+                copyToClipboard(text)
+                showToast("已复制")
+            }
+        }
+    }
+
+    private fun renderResult(name: String?, value: String) {
+        binding.resultTitleText.text = "✅ Token 「${name ?: ""}」创建成功"
+        binding.tokenValueText.text = value
+        showResultMode()
+    }
+
+    // ==================== 工具 ====================
+
+    private fun copyToClipboard(text: String) {
+        val cm = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        cm.setPrimaryClip(ClipData.newPlainText("api_token", text))
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // 展开底部弹窗
+        (dialog as? com.google.android.material.bottomsheet.BottomSheetDialog)?.behavior?.let {
+            it.state = com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
+            it.skipCollapsed = true
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onDismiss(dialog: android.content.DialogInterface) {
+        super.onDismiss(dialog)
+        // 清理已创建的 Token，避免下次重新打开时残留旧结果
+        viewModel.clearCreatedToken()
+    }
+
+    companion object {
+        private const val ARG_TOKEN = "token"
+        private const val ARG_EMAIL = "email"
+        private const val ARG_GLOBAL_KEY = "global_key"
+        private const val ARG_ACCOUNT_ID = "account_id"
+        private const val ARG_AUTH_TYPE = "auth_type"
+        private const val ARG_ACCOUNT_NAME = "account_name"
+
+        fun newInstance(account: Account): ApiTokenPermissionSheet {
+            return ApiTokenPermissionSheet().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_TOKEN, account.token)
+                    putString(ARG_EMAIL, account.email ?: "")
+                    putString(ARG_GLOBAL_KEY, account.globalApiKey ?: "")
+                    putString(ARG_ACCOUNT_ID, account.accountId)
+                    putString(ARG_AUTH_TYPE, account.authType)
+                    putString(ARG_ACCOUNT_NAME, account.name)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/muort/upworker/feature/account/ApiTokenViewModel.kt
+++ b/app/src/main/java/com/muort/upworker/feature/account/ApiTokenViewModel.kt
@@ -1,0 +1,163 @@
+package com.muort.upworker.feature.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.muort.upworker.core.model.Account
+import com.muort.upworker.core.model.AccountInfo
+import com.muort.upworker.core.model.ApiToken
+import com.muort.upworker.core.model.PermissionGroup
+import com.muort.upworker.core.model.Resource
+import com.muort.upworker.core.model.ScopeCategory
+import com.muort.upworker.core.model.ZoneInfo
+import com.muort.upworker.core.repository.ApiTokenRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class ApiTokenViewModel @Inject constructor(
+    private val apiTokenRepository: ApiTokenRepository
+) : ViewModel() {
+
+    /** 用于创建/校验的凭据账号（即左侧填写的 Token 对应的临时账号） */
+    private val _creatorAccount = MutableStateFlow<Account?>(null)
+    val creatorAccount: StateFlow<Account?> = _creatorAccount.asStateFlow()
+
+    private val _permissionGroups = MutableStateFlow<List<PermissionGroup>>(emptyList())
+    val permissionGroups: StateFlow<List<PermissionGroup>> = _permissionGroups.asStateFlow()
+
+    private val _permAccounts = MutableStateFlow<List<AccountInfo>>(emptyList())
+    val permAccounts: StateFlow<List<AccountInfo>> = _permAccounts.asStateFlow()
+
+    private val _permZones = MutableStateFlow<List<ZoneInfo>>(emptyList())
+    val permZones: StateFlow<List<ZoneInfo>> = _permZones.asStateFlow()
+
+    private val _currentTokenDetail = MutableStateFlow<ApiToken?>(null)
+    val currentTokenDetail: StateFlow<ApiToken?> = _currentTokenDetail.asStateFlow()
+
+    private val _createdToken = MutableStateFlow<ApiToken?>(null)
+    val createdToken: StateFlow<ApiToken?> = _createdToken.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private val _message = MutableSharedFlow<String>()
+    val message: SharedFlow<String> = _message.asSharedFlow()
+
+    fun setCreatorAccount(account: Account) {
+        _creatorAccount.value = account
+    }
+
+    /**
+     * 加载权限管理所需数据：权限组、账号、域名，并尝试校验+获取当前 Token 详情
+     */
+    fun loadPermissionData(account: Account) {
+        _creatorAccount.value = account
+        viewModelScope.launch {
+            _loading.value = true
+
+            // 并行加载权限组、账号、域名
+            val groupsJob = launch {
+                when (val r = apiTokenRepository.getPermissionGroups(account)) {
+                    is Resource.Success -> _permissionGroups.value = r.data
+                    is Resource.Error -> _message.emit("权限组加载失败: ${r.message}")
+                    is Resource.Loading -> {}
+                }
+            }
+            val accountsJob = launch {
+                when (val r = apiTokenRepository.listAccounts(account)) {
+                    is Resource.Success -> _permAccounts.value = r.data
+                    is Resource.Error -> Timber.w("perm accounts failed: ${r.message}")
+                    is Resource.Loading -> {}
+                }
+            }
+            val zonesJob = launch {
+                when (val r = apiTokenRepository.listZones(account)) {
+                    is Resource.Success -> _permZones.value = r.data
+                    is Resource.Error -> Timber.w("perm zones failed: ${r.message}")
+                    is Resource.Loading -> {}
+                }
+            }
+
+            groupsJob.join(); accountsJob.join(); zonesJob.join()
+
+            // 校验当前 Token 并获取详情（await，使 loading 覆盖整个加载过程）
+            loadCurrentTokenDetailImpl(account)
+
+            _loading.value = false
+        }
+    }
+
+    /** 校验当前 Token 并获取其完整权限详情（供刷新按钮调用，异步） */
+    fun loadCurrentTokenDetail(account: Account) {
+        viewModelScope.launch {
+            _loading.value = true
+            loadCurrentTokenDetailImpl(account)
+            _loading.value = false
+        }
+    }
+
+    private suspend fun loadCurrentTokenDetailImpl(account: Account) {
+        when (val v = apiTokenRepository.verifyToken(account)) {
+            is Resource.Success -> {
+                val id = v.data.id
+                if (!id.isNullOrBlank()) {
+                    when (val detail = apiTokenRepository.getTokenDetail(account, id)) {
+                        is Resource.Success -> _currentTokenDetail.value = detail.data
+                        is Resource.Error -> {
+                            // 部分权限下 verify 成功但无法读取详情
+                            _currentTokenDetail.value = v.data
+                            _message.emit("无法读取 Token 详情: ${detail.message}")
+                        }
+                        is Resource.Loading -> {}
+                    }
+                } else {
+                    _currentTokenDetail.value = v.data
+                }
+            }
+            is Resource.Error -> {
+                _currentTokenDetail.value = null
+                _message.emit("Token 校验失败: ${v.message}")
+            }
+            is Resource.Loading -> {}
+        }
+    }
+
+    /**
+     * 创建自定义权限 Token
+     */
+    fun createApiToken(
+        account: Account,
+        name: String,
+        selectedGroups: Map<ScopeCategory, List<PermissionGroup>>,
+        accountScope: ApiTokenRepository.AccountResourceScope,
+        zoneScope: ApiTokenRepository.ZoneResourceScope,
+        expiresOn: String?
+    ) {
+        viewModelScope.launch {
+            _loading.value = true
+            when (val r = apiTokenRepository.createApiToken(
+                account, name, selectedGroups, accountScope, zoneScope, expiresOn
+            )) {
+                is Resource.Success -> {
+                    _createdToken.value = r.data
+                    _message.emit("Token 创建成功")
+                }
+                is Resource.Error -> _message.emit("创建失败: ${r.message}")
+                is Resource.Loading -> {}
+            }
+            _loading.value = false
+        }
+    }
+
+    fun clearCreatedToken() {
+        _createdToken.value = null
+    }
+}

--- a/app/src/main/java/com/muort/upworker/feature/account/PermissionGroupAdapter.kt
+++ b/app/src/main/java/com/muort/upworker/feature/account/PermissionGroupAdapter.kt
@@ -1,0 +1,149 @@
+package com.muort.upworker.feature.account
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.checkbox.MaterialCheckBox
+import com.muort.upworker.R
+import com.muort.upworker.core.model.PermissionGroup
+import com.muort.upworker.core.model.ScopeCategory
+
+/** 权限列表项（分组标题或权限组） */
+sealed class PermissionItem {
+    data class Header(val title: String) : PermissionItem()
+    data class Group(val group: PermissionGroup, val category: ScopeCategory) : PermissionItem()
+}
+
+class PermissionGroupAdapter(
+    private val onSelectionChanged: () -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private val fullList = mutableListOf<PermissionItem>()
+    private val filteredList = mutableListOf<PermissionItem>()
+    private val selectedIds = mutableSetOf<String>()
+    private var query: String = ""
+
+    fun setData(items: List<PermissionItem>) {
+        fullList.clear()
+        fullList.addAll(items)
+        applyFilter()
+    }
+
+    fun setQuery(q: String) {
+        query = q.trim()
+        applyFilter()
+    }
+
+    private fun applyFilter() {
+        filteredList.clear()
+        if (query.isEmpty()) {
+            filteredList.addAll(fullList)
+        } else {
+            // 仅保留名称/说明匹配的权限组；保留仍有可见子项的标题
+            val matched = fullList.filterIsInstance<PermissionItem.Group>()
+                .filter { matches(it.group, query) }
+            val byCategory = matched.groupBy { it.category }
+            ScopeCategory.values().forEach { cat ->
+                val list = byCategory[cat]
+                if (!list.isNullOrEmpty()) {
+                    filteredList.add(PermissionItem.Header(titleFor(cat)))
+                    filteredList.addAll(list)
+                }
+            }
+        }
+        notifyDataSetChanged()
+    }
+
+    private fun matches(g: PermissionGroup, q: String): Boolean {
+        val ql = q.lowercase()
+        return g.name.lowercase().contains(ql) ||
+                (g.description?.lowercase()?.contains(ql) == true)
+    }
+
+    fun getSelectedIds(): Set<String> = selectedIds.toSet()
+
+    fun selectedCount(): Int = selectedIds.size
+
+    fun clearSelection() {
+        selectedIds.clear()
+        notifyDataSetChanged()
+        onSelectionChanged()
+    }
+
+    /** 选中当前过滤后可见的全部权限组 */
+    fun selectAllVisible() {
+        filteredList.filterIsInstance<PermissionItem.Group>().forEach {
+            selectedIds.add(it.group.id)
+        }
+        notifyDataSetChanged()
+        onSelectionChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int =
+        if (filteredList[position] is PermissionItem.Header) TYPE_HEADER else TYPE_GROUP
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return if (viewType == TYPE_HEADER) {
+            HeaderViewHolder(inflater.inflate(R.layout.item_permission_header, parent, false))
+        } else {
+            GroupViewHolder(inflater.inflate(R.layout.item_permission_group, parent, false))
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val item = filteredList[position]
+        when (holder) {
+            is HeaderViewHolder -> holder.bind(item as PermissionItem.Header)
+            is GroupViewHolder -> holder.bind(item as PermissionItem.Group)
+        }
+    }
+
+    override fun getItemCount(): Int = filteredList.size
+
+    inner class HeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val text: TextView = itemView.findViewById(R.id.headerText)
+        fun bind(item: PermissionItem.Header) {
+            text.text = item.title
+        }
+    }
+
+    inner class GroupViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val checkBox: MaterialCheckBox = itemView.findViewById(R.id.permCheckBox)
+        private val desc: TextView = itemView.findViewById(R.id.permDescText)
+
+        fun bind(item: PermissionItem.Group) {
+            checkBox.text = item.group.name
+            val d = item.group.description
+            if (d.isNullOrBlank()) {
+                desc.visibility = View.GONE
+            } else {
+                desc.visibility = View.VISIBLE
+                desc.text = d
+            }
+            // 先移除监听，再设置选中状态，避免回调重入
+            checkBox.setOnCheckedChangeListener(null)
+            checkBox.isChecked = item.group.id in selectedIds
+            val id = item.group.id
+            checkBox.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) selectedIds.add(id) else selectedIds.remove(id)
+                onSelectionChanged()
+            }
+            // 点击整行时切换复选框（由上面的监听同步 selectedIds，避免重复逻辑）
+            itemView.setOnClickListener { checkBox.isChecked = !checkBox.isChecked }
+        }
+    }
+
+    companion object {
+        private const val TYPE_HEADER = 0
+        private const val TYPE_GROUP = 1
+
+        fun titleFor(cat: ScopeCategory): String = when (cat) {
+            ScopeCategory.USER -> "用户权限（User）"
+            ScopeCategory.ACCOUNT -> "账号权限（Account）"
+            ScopeCategory.ZONE -> "域名权限（Zone）"
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_api_token_permission.xml
+++ b/app/src/main/res/layout/dialog_api_token_permission.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:fillViewport="true"
+    android:paddingBottom="24dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- 顶部标题栏 -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="8dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="API Token 权限管理"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <ImageButton
+                android:id="@+id/closeBtn"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:src="@android:drawable/ic_menu_close_clear_cancel"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="关闭" />
+        </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/loadingBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:indeterminate="true"
+            android:visibility="gone" />
+
+        <!-- 模式切换 -->
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/toggleGroup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="4dp"
+            app:singleSelection="true"
+            app:selectionRequired="true">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnViewCurrent"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="当前Token权限"
+                android:textSize="12sp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCreateNew"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="创建新Token"
+                android:textSize="12sp" />
+        </com.google.android.material.button.MaterialButtonToggleGroup>
+
+        <!-- ============ 当前 Token 权限（查看） ============ -->
+        <LinearLayout
+            android:id="@+id/currentSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="16dp">
+
+            <TextView
+                android:id="@+id/currentInfoText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="正在校验当前 Token…"
+                android:textSize="13sp"
+                android:textColor="?android:textColorSecondary"
+                android:fontFamily="monospace" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="权限策略"
+                android:textStyle="bold"
+                android:textSize="14sp" />
+
+            <LinearLayout
+                android:id="@+id/currentPoliciesContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <TextView
+                android:id="@+id/currentErrorText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:visibility="gone"
+                android:textSize="12sp"
+                android:textColor="@color/md_theme_error" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/refreshCurrentBtn"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="重新校验"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <!-- ============ 创建新 Token ============ -->
+        <LinearLayout
+            android:id="@+id/createSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="16dp"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="使用左侧填写的 Token 作为创建凭据（需具有 “API Tokens Write” 权限），生成一个权限受控的新 Token。"
+                android:textSize="11sp"
+                android:textColor="?android:textColorSecondary"
+                android:lineSpacingExtra="2dp" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:hint="新 Token 名称"
+                app:boxBackgroundMode="outline">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/tokenNameEdit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- 过期时间 -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="过期时间"
+                android:textStyle="bold"
+                android:textSize="13sp" />
+
+            <RadioGroup
+                android:id="@+id/expiryRadioGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radioNever"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="永不"
+                    android:checked="true"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radio7d"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="7天"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radio30d"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="30天"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radio90d"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="90天"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radio1y"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="1年"
+                    android:textSize="12sp" />
+            </RadioGroup>
+
+            <!-- 账号资源范围 -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="账号资源范围（Account 权限适用）"
+                android:textStyle="bold"
+                android:textSize="13sp" />
+
+            <RadioGroup
+                android:id="@+id/accountScopeRadio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radioAllAccounts"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="所有账号"
+                    android:checked="true"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radioSpecificAccount"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="指定账号"
+                    android:textSize="12sp" />
+            </RadioGroup>
+
+            <Spinner
+                android:id="@+id/accountSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+
+            <!-- 域名资源范围 -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="域名资源范围（Zone 权限适用）"
+                android:textStyle="bold"
+                android:textSize="13sp" />
+
+            <RadioGroup
+                android:id="@+id/zoneScopeRadio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radioAllZones"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="所有域名"
+                    android:checked="true"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/radioSpecificZone"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="指定域名"
+                    android:textSize="12sp" />
+            </RadioGroup>
+
+            <Spinner
+                android:id="@+id/zoneSpinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+
+            <!-- 搜索 -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:hint="搜索权限（如 DNS、Workers、R2）"
+                app:boxBackgroundMode="outline"
+                app:startIconDrawable="@android:drawable/ic_menu_search">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/searchEdit"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text"
+                    android:imeOptions="actionSearch" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginTop="8dp">
+
+                <TextView
+                    android:id="@+id/selectedCountText"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="已选 0 项"
+                    android:textSize="12sp"
+                    android:textColor="?android:textColorSecondary" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/selectAllVisibleBtn"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="全选可见"
+                    android:textSize="12sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/clearSelectionBtn"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="清空"
+                    android:textSize="12sp" />
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/permRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="320dp"
+                android:layout_marginTop="4dp"
+                android:clipToPadding="false"
+                android:paddingBottom="8dp"
+                android:overScrollMode="never" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/createTokenBtn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="创建 Token"
+                style="@style/Widget.Material3.Button" />
+        </LinearLayout>
+
+        <!-- ============ 创建结果 ============ -->
+        <LinearLayout
+            android:id="@+id/resultSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingTop="20dp"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/resultTitleText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="✅ Token 创建成功"
+                android:textStyle="bold"
+                android:textSize="16sp"
+                android:textColor="@color/md_theme_success" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="⚠️ Token 密钥仅显示一次，请立即复制保存："
+                android:textSize="12sp"
+                android:textColor="?android:textColorSecondary" />
+
+            <TextView
+                android:id="@+id/tokenValueText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:padding="12dp"
+                android:background="?attr/colorSurfaceVariant"
+                android:textIsSelectable="true"
+                android:fontFamily="monospace"
+                android:textSize="12sp"
+                android:text="token-value" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="12dp">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/copyTokenBtn"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="复制"
+                    android:layout_marginEnd="8dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/fillTokenBtn"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="填入 API Token"
+                    style="@style/Widget.Material3.Button" />
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/createAnotherBtn"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="再创建一个" />
+        </LinearLayout>
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_account_edit.xml
+++ b/app/src/main/res/layout/fragment_account_edit.xml
@@ -94,24 +94,47 @@
 
         </RadioGroup>
 
-        <!-- API Token 输入 -->
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tokenInputLayout"
+        <!-- API Token 输入 + 权限按钮 -->
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="API Token"
-            app:boxBackgroundMode="outline"
+            android:orientation="horizontal"
             android:layout_marginBottom="16dp"
-            app:endIconMode="password_toggle">
+            android:gravity="bottom">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/tokenEditText"
-                android:layout_width="match_parent"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tokenInputLayout"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:inputType="textPassword"
-                android:fontFamily="monospace" />
+                android:layout_weight="1"
+                android:hint="API Token"
+                app:boxBackgroundMode="outline"
+                app:endIconMode="password_toggle">
 
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/tokenEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword"
+                    android:fontFamily="monospace" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Button
+                android:id="@+id/tokenPermissionBtn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="权限"
+                android:textSize="12sp"
+                android:minWidth="0dp"
+                android:paddingHorizontal="14dp"
+                style="@style/Widget.Material3.Button.OutlinedButton.Icon"
+                app:icon="@android:drawable/ic_menu_manage"
+                app:iconSize="16dp"
+                app:iconPadding="4dp" />
+
+        </LinearLayout>
 
         <!-- Global API Key 认证区域 -->
         <LinearLayout

--- a/app/src/main/res/layout/item_permission_group.xml
+++ b/app/src/main/res/layout/item_permission_group.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="20dp"
+    android:paddingVertical="6dp"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true">
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/permCheckBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="0dp"
+        android:paddingEnd="0dp"
+        android:text="权限名称"
+        android:textSize="14sp"
+        android:minHeight="0dp" />
+
+    <TextView
+        android:id="@+id/permDescText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="-2dp"
+        android:text="权限说明"
+        android:textSize="11sp"
+        android:textColor="?android:textColorSecondary"
+        android:maxLines="2"
+        android:ellipsize="end" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_permission_header.xml
+++ b/app/src/main/res/layout/item_permission_header.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/headerText"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="20dp"
+    android:paddingTop="16dp"
+    android:paddingBottom="6dp"
+    android:text="分组标题"
+    android:textStyle="bold"
+    android:textSize="13sp"
+    android:textColor="?attr/colorPrimary"
+    android:background="?attr/colorSurfaceVariant" />


### PR DESCRIPTION
## 功能

在账号编辑页 **API Token 输入框旁新增「权限」小按钮**（齿轮图标），点击打开底部弹窗，支持：

1. **查看当前 Token 权限**：`verify` → `GET /user/tokens/{id}`，展示当前 Token 的每条策略（资源范围 + 权限组名称，可点击复制）。
2. **创建新 Token（权限受控）**：用左侧填写的 Token 作凭据创建一个新 Token，可一键回填到 API Token 输入框。

## 严格对齐 Cloudflare 创建 API Token 的权限模型（文档调研）

- 权限组来自 `GET /user/tokens/permission_groups`（`{id, name, description, scopes}`），**创建时只用 `id`**（`name` 易变）。
- 权限组按 `scopes` 自动归类为 **User / Account / Zone** 三类，UI 分组展示 + 搜索 + 全选/清空。
- 每种作用域生成**独立 policy**（Cloudflare 要求 policy 内权限组与 resources 作用域匹配）。
- 资源范围键严格按文档：
  - 单域名 `com.cloudflare.api.account.zone.<ZONE_ID>:"*"`
  - 所有域名 `com.cloudflare.api.account.zone.*:"*"`
  - 单/全部账号 `com.cloudflare.api.account.<ACCT>:"*"` / `com.cloudflare.api.account.*:"*"`
  - 账号内全部域名（嵌套）`com.cloudflare.api.account.<ACCT>:{com.cloudflare.api.account.zone.*:"*"}`
  - 用户 `com.cloudflare.api.user.<USER_TAG>:"*"`（`GET /user` 取 tag）
- 可选 TTL（7/30/90 天/1 年，ISO8601 UTC）。
- 创建结果 `value` 密钥**仅显示一次**，支持复制与一键回填。
- 权限不足时给出友好提示（需 \`API Tokens Read/Write\` 权限；Global API Key 可直接读取）。

## 改动文件

| 文件 | 作用 |
|---|---|
| `core/model/ApiTokenModels.kt` | PermissionGroup / TokenPolicy / CreateTokenRequest / ApiToken 等模型 |
| `core/network/CloudFlareApi.kt` | 新增端点：permission_groups、verify、token 详情、list、create、get user |
| `core/repository/ApiTokenRepository.kt` | 权限组获取、verify/详情、创建（按作用域构建 policy、资源范围 sealed 类） |
| `feature/account/ApiTokenViewModel.kt` | activity 作用域共享 VM，并行加载 + 创建流程 |
| `feature/account/PermissionGroupAdapter.kt` | 分组 + 搜索 + 复选的 RecyclerView 适配器 |
| `feature/account/ApiTokenPermissionSheet.kt` | 底部弹窗主体（BottomSheetDialogFragment） |
| `res/layout/dialog_api_token_permission.xml` 等 3 个布局 | 弹窗、权限项、分组头 |
| `res/layout/fragment_account_edit.xml` | API Token 行改为「输入框 + 权限按钮」横向布局 |
| `feature/account/AccountEditFragment.kt` | 接线按钮、实现回填回调 |

## 说明

- 本开发环境无 Android SDK / 可用 JVM，未能实际编译。已做细致人工审查：XML 通过 well-formed 校验、Kotlin 括号平衡，并修正了重复 \`companion object\`、sealed \`toResources()\` 抽象化、复选框回调重入、颜色资源误当 drawable 等问题。所有用到的 Material3 按钮样式（含 \`OutlinedButton.Icon\`、\`TonalButton\`）项目均已在使用。**建议合并前本地 \`./gradlew assembleDebug\` 跑一遍确认。**